### PR TITLE
Support for EU ROMs

### DIFF
--- a/src/actorlistloader_arm9.asm
+++ b/src/actorlistloader_arm9.asm
@@ -16,8 +16,8 @@
 .definelabel ActorEntryLen, 12
 
 ;Beginning of the npc table
-.org 0x020A6910
-.area 0x20A9208 - .
+.org ActNpcTable
+.area 0x28F8, 255 ; We null out the rest of the table, so we know something went wrong
 
 ;Uncomment desired method of access to the file's content
   ;.include "actor_accessor_fstream.asm" ;;;<============================== Because of the way actor function access the actor data, filestreams are not available!!!!
@@ -73,8 +73,6 @@
     .ascii "rom0:BALANCE/actor_list.bin"
     dcb 0 ;Ending 0!
   .align 4
-;Fill up the rest with junk so we know if something went wrong
-        .fill  (0x20A9208 - .), 255 ;Null out the rest of the table
 .endarea
 
 
@@ -83,8 +81,8 @@
 ;-------------------------------------
 ; 0x20240B0 Hook
 ;-------------------------------------
-.org 0x20240B0
-.area (0x2024114 - .)
+.org ActFn20240B0
+.area 0x64, 0
   push    r4-r8,r14
   mov     r8,r0
   mov     r7,r1
@@ -122,15 +120,14 @@
   mov     r0,0h
   pop     r4-r8,r15
   .pool
-  .fill (0x2024114 - .), 0
 .endarea
 
 
 ;-------------------------------------
 ; 0x2024114 Hook
 ;-------------------------------------
-.org 0x2024114
-.area (0x2024178 - .)
+.org ActFn2024114
+.area 0x64, 0
   push    r4-r8,r14
   mov     r8,r0
   mov     r7,r1
@@ -169,14 +166,13 @@
   ;02024170 020A7FF0
   ;02024174 00000182
   .pool
-  .fill (0x2024178 - .), 0
 .endarea
 
 ;-------------------------------------
 ; 0x2024178 Hook
 ;-------------------------------------
-.org 0x2024184
-.area (0x20241DC - .)
+.org ActFn2024184
+.area 0x58, 0
     push    r4-r8,r14
     mov     r8,r0
     mov     r7,r1
@@ -214,29 +210,27 @@
     ;020241D4 020A7FF0
     ;020241D8 00000182
     .pool
-    .fill (0x20241DC - .), 0
 .endarea
 
 ;-------------------------------------
 ; 0x2065050 Hook
 ;-------------------------------------
-.org 0x20650C0
+.org ActFn20650C0
 .area 16
     mov     r0,r2           ;020650C0 E3A0000C mov     r0,0Ch
     bl      ActorAccessor   ;020650C4 E1610082 smulbb  r1,r2,r0
     ldrsh   r0,[r0]         ;020650C8 E59F03C8 ldr     r0,=20A7FF0h
     nop                     ;020650CC E19000F1 ldrsh   r0,[r0,r1]
 .endarea
-.org 0x2065498 ;Can replace address to actor table in datapool
-.area 4
+.org ActFn20650C0 + 0x3D8 ;Can replace address to actor table in datapool
+.area 4, 0
   .pool
-  .fill (0x2065498 + 4) - .,0
 .endarea
 
 ;-------------------------------------
 ; 0x206549C Hook
 ;-------------------------------------
-.org 0x20654D0
+.org ActFn20654D0
 .area 20
   push r14                            ;020654D0 E3A0100C mov     r1,0Ch
   mov r1,r14                          ;020654D4 E163018E smulbb  r3,r14,r1
@@ -244,17 +238,16 @@
   pop r14                             ;020654DC E19C20F3 ldrsh   r2,[r12,r3]
   nop                                 ;020654E0 E08C3003 add     r3,r12,r3
 .endarea
-.org 0x2065964  ;Can replace address to actor table in datapool
-.area 4
+.org ActFn20654D0 + 0x494  ;Can replace address to actor table in datapool
+.area 4, 0
   .pool
-  .fill (0x2065964 + 4) - .,0
 .endarea
 
 ;-------------------------------------
 ; 0x2065B14 Hook
 ;-------------------------------------
-.org 0x2065B14
-.area (0x2065B3C - .)
+.org ActFn2065B14
+.area 0x28, 0
 push r14
   mvn     r1,0h
   cmp     r0,r1
@@ -266,5 +259,4 @@ push r14
   ldrh    r0,[r0,8h]
   pop     r15             ;bx      r14
   .pool
-  .fill (0x2065B3C - .), 0
 .endarea

--- a/src/actorlistloader_overlay11.asm
+++ b/src/actorlistloader_overlay11.asm
@@ -16,7 +16,7 @@
 ;-------------------------------------
 ; 0x22F7E78 Hook
 ;-------------------------------------
-.org 0x22F7F04
+.org ActFn22F7F04
 .area 28
   ;ldr     r7,=20A7FF0h
   ;mov     r12,0Ch
@@ -29,27 +29,25 @@
   mov     r4,r0
   mov     r0,1h               ;Don't Change this!
 .endarea
-.org 0x22F83E0      ;Can replace address to actor table in datapool
-.area 4
+.org ActFn22F7F04 + 0x4DC      ;Can replace address to actor table in datapool
+.area 4, 0
   .pool
-    .fill (0x22F83E0 + 4) - .,0
 .endarea
 
 ;-------------------------------------
 ; 0x22F8C18 Hook
 ;-------------------------------------
-.org 0x22F8C68
+.org Act22F8CD0-0x68
 .area 4
   nop       ;022F8C68 E59FB1F4 ldr     r11,=20A7FF0h
 .endarea
-.org 0x22F8CD0
+.org Act22F8CD0
 .area 12
   mov     r0,r1           ;022F8CD0 E3A0000C mov     r0,0Ch
   bl      ActorAccessor   ;022F8CD4 E1600081 smulbb  r0,r1,r0
   ldrsh   r0,[r0]         ;022F8CD8 E19B00F0 ldrsh   r0,[r11,r0]
 .endarea
-.org 0x22F8E64    ;Can replace address to actor table in datapool
-.area 4
+.org Act22F8CD0 + 0x194    ;Can replace address to actor table in datapool
+.area 4, 0
   .pool
-  .fill (0x22F8E64 + 4) - .,0
 .endarea

--- a/src/cmn_eos_eu.asm
+++ b/src/cmn_eos_eu.asm
@@ -1,0 +1,64 @@
+; For use with ARMIPS v0.7d
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; Copyright © 2020 Marco Köpcke <parakoopa@live.de>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+
+
+; Overlays load offsets
+;.definelabel Overlay_0010_offset, ???
+.definelabel Overlay_0011_offset, 0x22DCB80
+;.definelabel Overlay_0013_offset, ???
+
+; Known function offsets from the game's binaries:
+.definelabel LoadFileFromRom, 0x2008C3C
+.definelabel HandleSIR0,      0x201F550
+.definelabel DebugPrint,      0x200C2C8
+
+; Alloc
+.definelabel MemAlloc,        0x2001170     ;(r0 = SzAlloc, r1 = Align?) Returns r0 = PtrAllocated
+.definelabel MemFree,         0x2001188     ;(r0 = BufToFree)
+.definelabel MemAlloc2,       0x2001390     ;(r0 = unknown, r1 = SzAlloc, r1 = Align?) Returns r0 = PtrAllocated
+
+.definelabel MemZeroFill,     0x2003250     ;(r0 = PtrBuf, r1 = LengthBuffer)
+
+; file streams
+;.definelabel FStreamAlloc,    ???
+;.definelabel FStreamCtor,     ???
+;.definelabel FStreamFOpen,    ???
+;.definelabel FStreamSeek,     ???
+
+;.definelabel FStreamRead,     ???
+;.definelabel FStreamClose,    ???
+;.definelabel FStreamDealloc,  ???
+
+; Actor list patch offsets
+.definelabel ActNpcTable,     0x20A71B0
+.definelabel ActFn20240B0,    0x2024310
+.definelabel ActFn2024114,    0x2024374
+.definelabel ActFn2024184,    0x20243E4
+.definelabel ActFn20650C0,    0x206543C
+.definelabel ActFn20654D0,    0x206584C
+.definelabel ActFn2065B14,    0x2065E90
+.definelabel ActFn22F7F04,    0x22F88A4
+.definelabel Act22F8CD0,      0x22F9670
+
+; Level list patch offsets
+.definelabel LvlListTable,    0x20A4CEC
+.definelabel LvlFn2065014,    0x2065390
+.definelabel LvlFn2064FFC,    0x2065378
+.definelabel LvlFn2025AD8,    0x2025DA4
+.definelabel LvlFn22DE56C,    0x22DEEAC
+.definelabel LvlFn22F134C,    0x22F1CF0
+.definelabel LvlFn22F1600,    0x22F1FA4
+.definelabel LvlFn22F1758,    0x22F20FC
+.definelabel LvlFn22F17B4,    0x22F2158
+.definelabel LvlFn22F1F68,    0x22F290C
+.definelabel LvlFn22FF9FC,    0x2300398
+.definelabel LvlFn2310108,    0x2310AA4
+.definelabel LvlFn2310E1C,    0x23117B8
+.definelabel LvlFn231110C,    0x2311AA8
+.definelabel LvlFn23125D4,    0x2312FB4

--- a/src/cmn_eos_na.asm
+++ b/src/cmn_eos_na.asm
@@ -11,9 +11,9 @@
 
 
 ; Overlays load offsets
-.definelabel Overlay_0010_offset, 0x022BCA80
-.definelabel Overlay_0011_offset, 0x022DC240
-.definelabel Overlay_0013_offset, 0x0238A140
+.definelabel Overlay_0010_offset, 0x22BCA80
+.definelabel Overlay_0011_offset, 0x22DC240
+.definelabel Overlay_0013_offset, 0x238A140
 
 ; Known function offsets from the game's binaries:
 .definelabel LoadFileFromRom, 0x2008C3C
@@ -36,3 +36,31 @@
 .definelabel FStreamRead,     0x2008254     ;(r0 = PtrFStreamStruct, r1 = PtrOutBuffer, r2 = NbBytesToRead ) Read the ammount of bytes specified to the buffer, for the FStream object
 .definelabel FStreamClose,    0x20082C4     ;(r0 = PtrFStreamStruct)  Close the filestream
 .definelabel FStreamDealloc,  0x2008194     ;() ???
+
+; Actor list patch offsets
+.definelabel ActNpcTable,     0x20A6910
+.definelabel ActFn20240B0,    0x20240B0
+.definelabel ActFn2024114,    0x2024114
+.definelabel ActFn2024184,    0x2024184
+.definelabel ActFn20650C0,    0x20650C0
+.definelabel ActFn20654D0,    0x20654D0
+.definelabel ActFn2065B14,    0x2065B14
+.definelabel ActFn22F7F04,    0x22F7F04
+.definelabel Act22F8CD0,      0x22F8CD0
+
+; Level list patch offsets
+.definelabel LvlListTable,    0x20A46EC
+.definelabel LvlFn2065014,    0x2065014
+.definelabel LvlFn2064FFC,    0x2064FFC
+.definelabel LvlFn2025AD8,    0x2025AD8
+.definelabel LvlFn22DE56C,    0x22DE56C
+.definelabel LvlFn22F134C,    0x22F134C
+.definelabel LvlFn22F1600,    0x22F1600
+.definelabel LvlFn22F1758,    0x22F1758
+.definelabel LvlFn22F17B4,    0x22F17B4
+.definelabel LvlFn22F1F68,    0x22F1F68
+.definelabel LvlFn22FF9FC,    0x22FF9FC
+.definelabel LvlFn2310108,    0x2310108
+.definelabel LvlFn2310E1C,    0x2310E1C
+.definelabel LvlFn231110C,    0x231110C
+.definelabel LvlFn23125D4,    0x23125D4

--- a/src/levellistloader_arm9.asm
+++ b/src/levellistloader_arm9.asm
@@ -18,9 +18,9 @@
 ;First do am9.bin
 ;.open "../bin_src/arm9.bin", "../bin_out/arm9.bin", 0x02000000
     ;Implement our own file loading function to load the list as a sir0!
-    .org 0x020A46EC ;write over the actual table
+    .org LvlListTable ;write over the actual table
     ;.area 0x20A6910 - .;0x2224 ;We got at most 8,740 bytes to write stuff here, so there's plenty of room!
-    .area 0x20A68BC - .
+    .area 0x21D0, 255 ; We null out the rest of the table, so we know something went wrong
 
     ;Uncomment the desired implementation! Filestreams don't load the entire level list in memory, while the sir0 option loads the whole thing!
     ; Filestreams are slower and takes little memory, while the other consumes more memory but is very quick!
@@ -128,8 +128,6 @@
             .ascii "rom0:BALANCE/level_list.bin"      ;This is the name of SIR0 file that'll contain our level table!
             dcb 0 ;Put ending 0
         .align 4 ;align the string on 4bytes
-;Fill up the rest with junk so we know if something went wrong
-        .fill  (0x20A68BC - .), 255 ;Null out the rest of the table
     .endarea
 
 ;===============================================================================
@@ -139,8 +137,8 @@
 ;-------------------------------------
 ; Level Getter2 Hook
 ;-------------------------------------
-    .org 0x2065014
-    .area 0x2065050 - 0x2065014
+    .org LvlFn2065014
+    .area 0x3C
       push r1,r14
       mvn     r1,0h
       cmp     r0,r1
@@ -166,7 +164,7 @@
 ;-------------------------------------
 ; Level String Getter Hook
 ;-------------------------------------
-    .org 0x02064FFC
+    .org LvlFn2064FFC
     .area 0x18 ; we got 24 bytes max here
         push r14
         ;Call our modified routine
@@ -180,13 +178,12 @@
 ;-------------------------------------
 ; FontLoader Hook (For loading as SIR0 only)
 ;-------------------------------------
-    .org 0x2025AD8
-    .area (0x2025B7C - 0x2025AD8)
+    .org LvlFn2025AD8
+    .area 0xA4, 0
       push r14
       bl ReplacedFontLoader
       pop r15
       .pool
-      .fill (0x2025B7C - .),0
     .endarea
     ;END
 

--- a/src/levellistloader_overlay11.asm
+++ b/src/levellistloader_overlay11.asm
@@ -14,7 +14,7 @@
 ;-------------------------------------
 ; Hook 022F134C
 ;-------------------------------------
-  .org 0x22DE56C
+  .org LvlFn22DE56C
   .area 24  ;We have 24 bytes here
     ldrsh   r3,[r0,8h]
     mov     r0,r3
@@ -27,7 +27,7 @@
 ;-------------------------------------
 ; Hook 022F134C
 ;-------------------------------------
-  .org 0x22F134C
+  .org LvlFn22F134C
   .area 0x14  ;We have 20 bytes here
     ;Prepare the parameter for the accessor
     mov     r0,r5               ;022F134C E3A0000C mov     r0,0Ch
@@ -36,7 +36,7 @@
     ldrsh   r0,[r4]             ;022F1358 E19400F3 ldrsh   r0,[r4,r3]
     nop                         ;022F135C E0844003 add     r4,r4,r3
   .endarea
-  .org 0x22F1540         ;We need to modify the address here, to use it for our bl above!
+  .org LvlFn22F134C + 0x1F4         ;We need to modify the address here, to use it for our bl above!
   .area 4
     .pool
   .endarea
@@ -44,7 +44,7 @@
 ;-------------------------------------
 ; Hook 022F1600
 ;-------------------------------------
-  .org 0x22F1600
+  .org LvlFn22F1600
   .area 0x14
     ;Prepare the parameter for the accessor
     mov     r0,r8                 ;022F1600 E3A0000C mov     r0,0Ch
@@ -53,7 +53,7 @@
     ldrsh   r0,[r4]               ;022F160C E19200F1 ldrsh   r0,[r2,r1]
     nop                           ;022F1610 E0824001 add     r4,r2,r1
   .endarea
-  .org 0x22F16FC
+  .org LvlFn22F1600 + 0xFC
   .area 4
     .pool
   .endarea
@@ -61,7 +61,7 @@
   ;-------------------------------------
   ; Hook 022F1758
   ;-------------------------------------
-  .org 0x22F1758
+  .org LvlFn22F1758
   .area 24
     mov     r0,r4               ;022F1758 E59F1034 ldr     r1,=20A5488h   //<-change       //Level list beg
     ldr     r3,[r2,4h]          ;!! Don't touch !!
@@ -70,7 +70,7 @@
     ldrsh   r1,[r0,4h]          ;022F1768 E1001084 smlabb  r0,r4,r0,r1
     nop                         ;022F176C E1D010F4 ldrsh   r1,[r0,4h]
   .endarea
-  .org 0x22F1794
+  .org LvlFn22F1758 + 0x3C
   .area 4
     .pool
   .endarea
@@ -78,8 +78,8 @@
   ;-------------------------------------
   ; Hook 0x22F17B4 - This one caused misalignment in the stack!!
   ;-------------------------------------
-  .org 0x22F17B4
-  .area (0x22F17E4 - 0x22F17B4)
+  .org LvlFn22F17B4
+  .area 0x30
     push r14                  ;022F17B4 E59F0024 ldr     r0,=2324CC0h
     ldr     r0,=2324CC0h       ;022F17B8 E5900004 ldr     r0,[r0,4h]
     ldr     r0,[r0,4h]         ;022F17BC E3500000 cmp     r0,0h
@@ -99,7 +99,7 @@
   ;-------------------------------------
   ; Hook 022F1F68
   ;-------------------------------------
-  .org 0x22F1F68
+  .org LvlFn22F1F68
   .area 20
     nop ;mov     r0,r4             ;022F1F68 E3A0300C mov     r3,0Ch
     mov     r1,r7             ;!! Don't Touch !!
@@ -107,11 +107,11 @@
     bl      LevelListCustomHook022F1F68 ;022F1F74 E1640384 smulbb  r4,r4,r3 ;;<== Custom hook for this one since we don't have much space, and a lot of registers are in use!
     nop ;022F1F78 E59F50C8 ldr     r5,=20A5488h ;;;Put the result into r4 since r0 gets overwritten several times after, not r4 and r5
   .endarea
-  .org 0x22F1FD8
+  .org LvlFn22F1F68 + 0x70
   .area 4
     ldrsh   r0,[r4]           ;022F1FD8 E19500F4 ldrsh   r0,[r5,r4]
   .endarea
-  .org 0x22F2048
+  .org LvlFn22F1F68 + 0xE0
   .area 4
     .pool
   .endarea
@@ -119,7 +119,7 @@
   ;-------------------------------------
   ; Hook 022FF9FC
   ;-------------------------------------
-  .org 0x22FF9FC
+  .org LvlFn22FF9FC
   .area 24
     push r14
     mov     r0,r1                 ;022FF9FC E59F200C ldr     r2,=20A5488h
@@ -134,7 +134,7 @@
   ;-------------------------------------
   ; Hook 0x2310108
   ;-------------------------------------
-  .org 0x2310108
+  .org LvlFn2310108
   .area 20
     mov     r0,r5             ;02310108 E3A0000C mov     r0,0Ch
     bl      LevelListAccessor ;0231010C E1610085 smulbb  r1,r5,r0
@@ -142,7 +142,7 @@
     ldrsh   r0,[r4]           ;02310114 E19300F1 ldrsh   r0,[r3,r1]
     nop                       ;02310118 E0834001 add     r4,r3,r1
   .endarea
-  .org 0x2310328
+  .org LvlFn2310108 + 0x220
   .area 4
     .pool
   .endarea
@@ -150,32 +150,32 @@
   ;-------------------------------------
   ; Hook 0x2310E1C
   ;-------------------------------------
-  .org 0x2310E1C
+  .org LvlFn2310E1C
   .area 4
     nop     ;02310E1C E3A0000C mov     r0,0Ch        //<-change
   .endarea
   ;02310E20 E2811902 add     r1,r1,8000h
   ;02310E24 E5861000 str     r1,[r6]
   ;02310E28 E5962004 ldr     r2,[r6,4h]
-  .org 0x2310E2C
+  .org LvlFn2310E1C + 0x10
   .area 4
     nop     ;02310E2C E1610084 smulbb  r1,r4,r0      //<-change
   .endarea
   ;02310E30 E2820A06 add     r0,r2,6000h
   ;02310E34 E5860004 str     r0,[r6,4h]
   ;02310E38 E5952000 ldr     r2,[r5]
-  .org 0x2310E3C
+  .org LvlFn2310E1C + 0x20
   .area 4
     mov     r0,r4  ;02310E3C E59F0080 ldr     r0,=20A5488h  //<-change
   .endarea
   ;02310E40 E2422902 sub     r2,r2,8000h
   ;02310E44 E5852000 str     r2,[r5]
   ;02310E48 E5952004 ldr     r2,[r5,4h]
-  .org 0x2310E4C
+  .org LvlFn2310E1C + 0x30
   .area 4
     bl    LevelListFirstHWORDGet ;02310E4C E19000F1 ldrsh   r0,[r0,r1]    //<-change
   .endarea
-  .org 0x2310EC4
+  .org LvlFn2310E1C + 0xA8
   .area 4
     .pool
   .endarea
@@ -183,7 +183,7 @@
   ;-------------------------------------
   ; Hook 0x231110C
   ;-------------------------------------
-  .org 0x231110C
+  .org LvlFn231110C
   .area 20
     mov     r0,r5             ;0231110C E3A0000C mov     r0,0Ch
     bl      LevelListAccessor ;02311110 E1610085 smulbb  r1,r5,r0
@@ -191,7 +191,7 @@
     ldrsh   r0,[r4]           ;02311118 E19300F1 ldrsh   r0,[r3,r1]
     nop                       ;0231111C E0834001 add     r4,r3,r1
   .endarea
-  .org 0x02311278
+  .org LvlFn231110C + 0x16C
   .area 4
     .pool
   .endarea
@@ -199,7 +199,7 @@
   ;-------------------------------------
   ; Hook 0x23125D4
   ;-------------------------------------
-  .org 0x23125D4
+  .org LvlFn23125D4
   .area 20
     mov     r0,r5             ;023125D4 E3A0000C mov     r0,0Ch
     bl      LevelListAccessor ;023125D8 E1610085 smulbb  r1,r5,r0
@@ -207,7 +207,7 @@
     ldrsh   r0,[r4]           ;023125E0 E19300F1 ldrsh   r0,[r3,r1]
     nop                       ;023125E4 E0834001 add     r4,r3,r1
   .endarea
-  .org 0x0231271C
+  .org LvlFn23125D4 + 0x148
   .area 4
     .pool
   .endarea


### PR DESCRIPTION
- Only the patches themselves are changed, there's no 'entrypoint' for
  executing the EU patch yet.
- Moved the NA address offsets to new labels in the common file
- 'Translated' the offsets to the EU version and filled them in the EU
  version of the common file.

Sadly it doesn't work on the EU ROM yet, the game crashes on boot. The
addresses should be correct, though.