### PR TITLE
Support for the Japanese version

### DIFF
--- a/build_all_mods_jp.bat
+++ b/build_all_mods_jp.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+REM cd src
+mkdir "bin_out"
+mkdir "bin_out/overlay"
+mkdir "build"
+
+"armips/armips.exe" "src/jp/all_mods.asm" -temp "build/output.txt" -sym "build/symfile.sym" -erroronwarning
+pause

--- a/src/cmn_eos_eu.asm
+++ b/src/cmn_eos_eu.asm
@@ -13,7 +13,7 @@
 ; Overlays load offsets
 .definelabel Overlay_0010_offset, 0x022BD3C0 ;OK
 .definelabel Overlay_0011_offset, 0x022DCB80 ;OK
-.definelabel Overlay_0013_offset, 0x0238A880 ;OK
+.definelabel Overlay_0013_offset, 0x0238AC80 ;OK
 
 ; Known function offsets from the game's binaries:
 .definelabel LoadFileFromRom, 0x2008C3C ;OK

--- a/src/cmn_eos_jp.asm
+++ b/src/cmn_eos_jp.asm
@@ -1,0 +1,38 @@
+; For use with ARMIPS v0.7d
+; By: psycommando@gmail.com
+; 2016/08/18 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+
+
+; Overlays load offsets
+.definelabel Overlay_0010_offset, 0x022BE220
+.definelabel Overlay_0011_offset, 0x022DD8E0
+.definelabel Overlay_0013_offset, 0x0238B6A0
+
+; Known function offsets from the game's binaries:
+.definelabel LoadFileFromRom, 0x2008C3C
+.definelabel HandleSIR0,      0x201F50C
+.definelabel DebugPrint,      0x200C240
+
+; Alloc
+.definelabel MemAlloc,        0x2001170     ;(r0 = SzAlloc, r1 = Align?) Returns r0 = PtrAllocated
+.definelabel MemFree,         0x2001188     ;(r0 = BufToFree)
+.definelabel MemAlloc2,       0x2001390     ;(r0 = unknown, r1 = SzAlloc, r1 = Align?) Returns r0 = PtrAllocated
+
+.definelabel MemZeroFill,     0x2003250     ;(r0 = PtrBuf, r1 = LengthBuffer)
+
+; file streams
+.definelabel FStreamAlloc,    0x2008168     ;() Is usually done first, before any reading is done. Seems to instantiate the Filestream?
+.definelabel FStreamCtor,     0x2008204     ;(r0 = PtrFStreamStruct)  Zeroes the content of the struct
+.definelabel FStreamFOpen,    0x2008210     ;(r0 = PtrFStreamStruct, r1 = PtrFPath) Open the file for reading
+.definelabel FStreamSeek,     0x20082A8     ;(r0 = PtrFStreamStruct, r1 = OffsetToSeekTo, r2 = unknown?(usually 0) )
+;2008244h
+.definelabel FStreamRead,     0x2008254     ;(r0 = PtrFStreamStruct, r1 = PtrOutBuffer, r2 = NbBytesToRead ) Read the ammount of bytes specified to the buffer, for the FStream object
+.definelabel FStreamClose,    0x20082C4     ;(r0 = PtrFStreamStruct)  Close the filestream
+.definelabel FStreamDealloc,  0x2008194     ;() ???

--- a/src/jp/actorlistloader_arm9.asm
+++ b/src/jp/actorlistloader_arm9.asm
@@ -1,0 +1,270 @@
+; For use with ARMIPS v0.7d
+; By: psycommando@gmail.com
+; 2016/08/16 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+;Meant to be included inside the arm9.bin file!
+.relativeinclude on
+.nds
+.arm
+
+.definelabel ActorEntryLen, 12
+
+;Beginning of the npc table
+.org 0x020A7D58 ; OK
+.area 0x20AA650 - . ; OK
+
+;Uncomment desired method of access to the file's content
+  ;.include "../actor_accessor_fstream.asm" ;;;<============================== Because of the way actor function access the actor data, filestreams are not available!!!!
+  .include "../actor_accessor_sir0.asm"
+
+;Accessor, returns address entry specified (r0 = npc id) returns in r0 the address of the entry
+  ActorAccessor:
+    push r1,r2,r14
+      mov     r2,r0                   ;Save actor id in r2
+      bl      GetActorListAddress
+      mov     r1,ActorEntryLen        ;Each entries in the table is 12 bytes long
+      smulbb  r1,r2,r1                ;Multiply by the size of a table entry
+      add     r0,r0,r1                ;set it to the correct entry
+    pop r1,r2,r15
+    .pool
+    .align 4
+;END ActorAccessor
+
+;Custom hook for function ???
+  ActorListCustomHookUnknown:
+    push r0,r14
+      bl      GetActorListAddress
+      mov     r5,r0
+      bl      GetNbActors
+      mov     r4,r0
+      ;mov r0,r6 ;Get the counter as actor id
+      ;bl ActorAccessor
+      ;mov r5,r0 ;put the address into r5, r0 gets overwritten after so we don't care
+      ;ldr r1,[r5,4h]
+    pop r0,r15
+  .pool
+  .align 4
+;END ActorAccessor
+
+;Custom hook for function 02065784 (r1=actorid,) returns in r2 the first short, and in r3 the address of the entry!
+  ActorListCustomHook02065784:
+    push r0,r12,r14
+      mov     r0,r1                 ;Get the actor id into r0
+      mov     r12,r0                ;Save entry id in r12!
+      bl      GetActorListAddress
+      mov     r1,ActorEntryLen      ;Each entries in the table is 12 bytes long
+      smulbb  r1,r12,r1             ;Multiply entry id by the size of a table entry
+      add     r3,r0,r1              ;Place the entry's address into r3
+      ldrsh   r2,[r3]               ;Place the first half-word in the entry into r2
+      ;mov     r1,r12
+    pop r0,r12,r15
+  .pool
+  .align 4
+;END ActorAccessor
+
+;Filename for actors file
+  ActorListFilePath:
+    .ascii "rom0:BALANCE/actor_list.bin"
+    dcb 0 ;Ending 0!
+  .align 4
+;Fill up the rest with junk so we know if something went wrong
+        .fill  (0x20AA650 - .), 255 ;Null out the rest of the table
+.endarea
+
+
+;Approx locations to replace:
+
+;-------------------------------------
+; 0x2024100 Hook
+;-------------------------------------
+.org 0x2024100 ; OK
+.area (0x2024164 - .) ; OK
+  push    r4-r8,r14
+  mov     r8,r0
+  mov     r7,r1
+  ;ldr     r5,=20A7FF0h ; unused!
+  mov     r6,0h
+  ;ldr     r4,=182h ;Fill in the size with accessor!
+
+  ;Get the nb of actor here in the 2 instructions we've freed!
+  ;bl GetNbActors
+  ;mov r4,r0
+  bl ActorListCustomHookUnknown
+
+  b       @@LBL2
+  @@LOOP_BEG1:
+  ldr     r1,[r5,4h] ;<================ ACCESSOR HERE
+
+  ;Get the address of the actor entry, place it in r5.
+  ;bl ActorListCustomHookUnknown ;This will set the register up correctly!
+
+  mov     r0,r7
+  bl      202369Ch          //0202369C Compare NPC names! ; OK
+  cmp     r0,0h
+  beq     @@LBL1
+  mov     r1,r6,lsl 10h
+  mov     r0,r8
+  mov     r1,r1,asr 10h
+  bl      2023DB4h ; OK
+  pop     r4-r8,r15
+  @@LBL1:
+  add     r6,r6,1h
+  add     r5,r5,0Ch ;Don't need to do this with the accessor!
+  @@LBL2:
+  cmp     r6,r4
+  blt     @@LOOP_BEG1
+  mov     r0,0h
+  pop     r4-r8,r15
+  .pool
+  .fill (0x2024164 - .), 0
+.endarea
+
+
+;-------------------------------------
+; 0x2024164 Hook
+;-------------------------------------
+.org 0x2024164 ; OK
+.area (0x20241C8 - .) ; OK
+  push    r4-r8,r14
+  mov     r8,r0
+  mov     r7,r1
+  ;ldr     r5,=20A7FF0h
+  mov     r6,0h
+  ;ldr     r4,=182h
+
+  ;Get the nb of actor here in the 2 instructions we've freed!
+  ;bl GetNbActors
+  ;mov r4,r0
+  bl ActorListCustomHookUnknown
+
+  b       @@LBL1
+  @@LOOP_BEG1:
+  ldr     r1,[r5,4h]
+  ;Get the address of the actor entry, place it in r5.
+  ;bl ActorListCustomHookUnknown ;This will set the register up correctly!
+
+  mov     r0,r7
+  bl      202369Ch ; OK
+  cmp     r0,0h
+  beq     @@LBL2
+  mov     r1,r6,lsl 10h
+  mov     r0,r8
+  mov     r1,r1,asr 10h
+  bl      2023E10h ; OK
+  pop     r4-r8,r15
+  @@LBL2:
+  add     r6,r6,1h
+  add     r5,r5,0Ch
+  @@LBL1:
+  cmp     r6,r4
+  blt     @@LOOP_BEG1
+  mov     r0,0h
+  pop     r4-r8,r15
+  ;02024170 020A7FF0
+  ;02024174 00000182
+  .pool
+  .fill (0x20241C8 - .), 0
+.endarea
+
+;-------------------------------------
+; 0x20241C8 Hook
+;-------------------------------------
+.org 0x20241C8 ; OK
+.area (0x202422C - .) ; OK
+    push    r4-r8,r14
+    mov     r8,r0
+    mov     r7,r1
+    ;ldr     r5,=20A7FF0h
+    mov     r6,0h
+    ;ldr     r4,=182h
+
+    ;Get the nb of actor here in the 2 instructions we've freed!
+    ;bl GetNbActors
+    ;mov r4,r0
+    bl ActorListCustomHookUnknown
+
+    b       @@LBL1
+    @@LOOP_BEG1:
+    ldr     r1,[r5,4h]
+  ;Get the address of the actor entry, place it in r5.
+    ;bl ActorListCustomHookUnknown ;This will set the register up correctly!
+    mov     r0,r7
+    bl      202369Ch ; OK
+    cmp     r0,0h
+    beq     @@LBL2
+    mov     r1,r6,lsl 10h
+    mov     r0,r8
+    mov     r1,r1,asr 10h
+    bl      2024004h ; OK
+    pop     r4-r8,r15
+    @@LBL2:
+    add     r6,r6,1h
+    add     r5,r5,0Ch
+    @@LBL1:
+    cmp     r6,r4
+    blt     @@LOOP_BEG1
+    mov     r0,0h
+    pop     r4-r8,r15
+    ;020241D4 020A7FF0
+    ;020241D8 00000182
+    .pool
+    .fill (0x202422C - .), 0 ; OK
+.endarea
+
+;-------------------------------------
+; 0x20653A8 Hook
+;-------------------------------------
+.org 0x20653A8 ; OK
+.area 16
+    mov     r0,r2           ;020650C0 E3A0000C mov     r0,0Ch
+    bl      ActorAccessor   ;020650C4 E1610082 smulbb  r1,r2,r0
+    ldrsh   r0,[r0]         ;020650C8 E59F03C8 ldr     r0,=20A7FF0h
+    nop                     ;020650CC E19000F1 ldrsh   r0,[r0,r1]
+.endarea
+.org 0x2065780 ;Can replace address to actor table in datapool ; OK
+.area 4
+  .pool
+  .fill (0x2065780 + 4) - .,0 ; OK
+.endarea
+
+;-------------------------------------
+; 0x2065784 Hook
+;-------------------------------------
+.org 0x20657B8 ; OK
+.area 20
+  push r14                            ;020654D0 E3A0100C mov     r1,0Ch
+  mov r1,r14                          ;020654D4 E163018E smulbb  r3,r14,r1
+  bl  ActorListCustomHook02065784     ;020654D8 E59FC484 ldr     r12,=20A7FF0h
+  pop r14                             ;020654DC E19C20F3 ldrsh   r2,[r12,r3]
+  nop                                 ;020654E0 E08C3003 add     r3,r12,r3
+.endarea
+.org 0x2065C4C  ;Can replace address to actor table in datapool
+.area 4
+  .pool
+  .fill (0x2065C4C + 4) - .,0 ; OK
+.endarea
+
+;-------------------------------------
+; 0x2065DFC Hook
+;-------------------------------------
+.org 0x2065DFC ; OK
+.area (0x2065E24 - .) ; OK
+push r14
+  mvn     r1,0h
+  cmp     r0,r1
+  moveq   r0,0h
+  popeq   r15 ;bxeq    r14
+  ;ldr     r2,=20A7FF0h
+  bl ActorAccessor    ;mov     r1,0Ch
+  ;smlabb  r0,r0,r1,r2
+  ldrh    r0,[r0,8h]
+  pop     r15             ;bx      r14
+  .pool
+  .fill (0x2065E24 - .), 0 ; OK
+.endarea

--- a/src/jp/actorlistloader_overlay11.asm
+++ b/src/jp/actorlistloader_overlay11.asm
@@ -1,0 +1,55 @@
+; For use with ARMIPS v0.7d
+; By: psycommando@gmail.com
+; 2016/08/16 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+;Meant to be included inside the overlay_0011.bin file!
+.relativeinclude on
+.nds
+.arm
+
+;-------------------------------------
+; 0x22F94FC Hook
+;-------------------------------------
+.org 0x22F9588 ; OK
+.area 28
+  ;ldr     r7,=20A7FF0h
+  ;mov     r12,0Ch
+  ldr     r1,=2322ED8h        ;Don't Change this! ;"GroundLives Locate id %3d  kind %3d  index %3d" ; OK
+  mov     r2,r9               ;Don't Change this!
+  str     r4,[r13]            ;Don't Change this!
+  ;smlabb  r4,r3,r12,r7
+  mov     r0,r3
+  bl      ActorAccessor
+  mov     r4,r0
+  mov     r0,1h               ;Don't Change this!
+.endarea
+.org 0x22F9A64      ;Can replace address to actor table in datapool
+.area 4
+  .pool
+    .fill (0x22F9A64 + 4) - .,0
+.endarea
+
+;-------------------------------------
+; 0x22FA29C Hook
+;-------------------------------------
+.org 0x22FA2EC ; OK
+.area 4
+  nop       ;022FA2EC E59FB1F4 ldr     r11,=20A7FF0h
+.endarea
+.org 0x22FA354 ; OK
+.area 12
+  mov     r0,r1           ;022FA354 E3A0000C mov     r0,0Ch
+  bl      ActorAccessor   ;022FA358 E1600081 smulbb  r0,r1,r0
+  ldrsh   r0,[r0]         ;022FA35C E19B00F0 ldrsh   r0,[r11,r0]
+.endarea
+.org 0x22FA4E8    ;Can replace address to actor table in datapool ; OK
+.area 4
+  .pool
+  .fill (0x22FA4E8 + 4) - .,0 ; OK
+.endarea

--- a/src/jp/all_mods.asm
+++ b/src/jp/all_mods.asm
@@ -1,7 +1,7 @@
 ; For use with ARMIPS v0.7d
 ; By: psycommando@gmail.com
-; 2016/08/16 - Updated 2020/11/17
-; For Explorers of Sky Europe ONLY!
+; 2016/08/16 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
 ; ------------------------------------------------------------------------------
 ; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
 ; This work is free. You can redistribute it and/or modify it under the
@@ -12,7 +12,7 @@
 .relativeinclude on
 .nds
 .arm
-.definelabel PPMD_GameVer,    1       ;Symbol for telling the library we're compiled for EoS Europe "1"
+.definelabel PPMD_GameVer,    2       ;Symbol for telling the library we're compiled for EoS Japan "2"
 .include "../cmn_eos.asm"
 
 ; ================
@@ -29,13 +29,13 @@
 ; ========================
 ; === overlay_0010.bin ===
 ; ========================
-.open "../../bin_src/overlay_0010.bin", "../../bin_out/overlay/overlay_0010.bin", 0x022BD3C0 ;EoS EU because can't replace at compilation!
+.open "../../bin_src/overlay_0010.bin", "../../bin_out/overlay/overlay_0010.bin", 0x022BE220 ;EoS JP because can't replace at compilation!
 .close ;Close overlay_0010.bin
 
 ; ========================
 ; === overlay_0011.bin ===
 ; ========================
-.open "../../bin_src/overlay_0011.bin", "../../bin_out/overlay/overlay_0011.bin", 0x022DCB80 ;EoS EU because can't replace at compilation!
+.open "../../bin_src/overlay_0011.bin", "../../bin_out/overlay/overlay_0011.bin", 0x022DD8E0 ;EoS JP because can't replace at compilation!
   ; --- Level list loader ---
   .include "levellistloader_overlay11.asm"
 
@@ -46,5 +46,5 @@
 ; ========================
 ; === overlay_0013.bin ===
 ; ========================
-.open "../../bin_src/overlay_0013.bin", "../../bin_out/overlay/overlay_0013.bin", 0x0238AC80 ;EoS EU because can't replace at compilation!
+.open "../../bin_src/overlay_0013.bin", "../../bin_out/overlay/overlay_0013.bin", 0x0238B6A0 ;EoS JP because can't replace at compilation!
 .close ;Close overlay_0013.bin

--- a/src/jp/levellistloader_arm9.asm
+++ b/src/jp/levellistloader_arm9.asm
@@ -1,0 +1,193 @@
+; For use with ARMIPS v0.7d
+; By: psycommando@gmail.com
+; 2016/08/16 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+;Meant to be included inside the arm9.bin file!
+.relativeinclude on
+.nds
+.arm
+
+;.definelabel PPMD_GameVer,    2       ;Symbol for telling the library we're compiled for EoS Japan "2"
+
+;First do arm9.bin
+;.open "../bin_src/arm9.bin", "../bin_out/arm9.bin", 0x02000000
+    ;Implement our own file loading function to load the list as a sir0!
+    .org 0x020A5AD0 ;write over the actual table ; OK
+    ;.area 0x20A7D58 - .;0x2288 ;We got at most 8,840 bytes to write stuff here, so there's plenty of room!
+    .area 0x20A7D04 - . ; OK
+
+    ;Uncomment the desired implementation! Filestreams don't load the entire level list in memory, while the sir0 option loads the whole thing!
+    ; Filestreams are slower and takes little memory, while the other consumes more memory but is very quick!
+    ;.include "../levellistloader_cachedfstream.asm"
+    .include "../levellistloader_assir0.asm"
+
+;********************************
+; A few customized functions for making a more seamless hooking!
+;********************************
+;Same as above, except it returns the pointer to the string of the level, instead of the entry!
+        LevelListStringAccessor:
+          push r14
+          bl LevelListAccessor  ;Get the pointer to the entry
+          ;add r0,r0,8h        ;Increment to get the pointer to the string
+          ldr r0,[r0,8h]          ;Read the pointer to the string into r0
+          pop r15
+          .pool
+          .align 4
+        ;END LevelListStringAccessor
+
+;Helper for getting the first hword and return it into r0.
+        LevelListFirstHWORDGet:
+            push  r14
+            bl    LevelListAccessor
+            ldrsh r0,[r0]
+            pop   r15
+            .pool
+            .align 4
+        ;END
+
+;Helper for getting the first hword and return it into r0.
+        LevelListSecondHWORDGet:
+            push  r14
+            bl    LevelListAccessor
+            ldrsh r0,[r0,2h]
+            pop   r15
+            .pool
+            .align 4
+        ;END
+
+;Custom Hook for 022F35B4
+        LevelListCustomHook022F35B4: ; OK
+          push r0,r1,r2,r3,r14
+          mov r0,r4
+          bl  LevelListAccessor
+          mov r4,r0
+          pop r0,r1,r2,r3,r15
+          .pool
+          .align 4
+        ;END
+
+;********************************
+; Fontloader hook
+;********************************
+;A re-implementation of the font loader so the level table is loaded earlier.
+; The fonts are the first thing loaded in memory, so its probably going to be very
+; helpful to have this !!
+        ReplacedFontLoader:
+          push    r3,r14
+          bl      TryLoadLevelList  ;<=== We added our function to load the level list here
+          bl      TryLoadActorList 
+
+          ;The original code is below:
+          ;Please note that the JP version is slightly different in implementation from its NA/EU counterparts!
+          sub     r13,r13,8h
+          ldr     r1,=209B548h ; OK
+          add     r0,r13,0h
+          mov     r2,1h
+          bl      LoadFileFromRom                ;LoadFileFromRom(R1=filepath)
+          ldr     r1,[r13]
+          ldr     r0,=022A92C0h ; OK
+          bl      HandleSIR0
+          ldr     r1,=209B558h ; OK
+          add     r0,r13,0h
+          mov     r2,1h
+          bl      LoadFileFromRom                ;LoadFileFromRom(R1=filepath)
+          ldr     r1,[r13]
+          ldr     r0,=022A92C4h ; OK
+          bl      HandleSIR0
+          ldr     r1,=209B56Ch ; OK
+          add     r0,r13,0h
+          mov     r2,1h
+          bl      LoadFileFromRom                ;LoadFileFromRom(R1=filepath)
+          ldr     r2,[r13]
+          ldr     r0,=20B114Ch ; OK
+          mov     r1,0h
+          str     r2,[r0]
+          str     r1,[r0,4h]
+          ldr     r0,=022A92B4h ; OK
+          mov     r1,0Bh
+          str     r1,[r0,4h]
+          str     r1,[r0,8h]
+          mov     r1,1h
+          strb    r1,[r0]
+          add     r13,r13,8h
+          pop     r3,r15
+        .pool
+        ;END
+
+
+        LevelListFPath:
+            .ascii "rom0:BALANCE/level_list.bin"      ;This is the name of SIR0 file that'll contain our level table!
+            dcb 0 ;Put ending 0
+        .align 4 ;align the string on 4bytes
+;Fill up the rest with junk so we know if something went wrong
+        .fill  (0x20A7D04 - .), 255 ;Null out the rest of the table ; OK
+    .endarea
+
+;===============================================================================
+; Replace all instances of the table address with our hacked functions
+;===============================================================================
+
+;-------------------------------------
+; Level Getter2 Hook
+;-------------------------------------
+    .org 0x20652FC ; OK
+    .area 0x2065338 - 0x20652FC ; OK
+      push r1,r14
+      mvn     r1,0h
+      cmp     r0,r1
+      beq     @@Abort
+      ;mov     r1,0Ch
+      ;smulbb  r1,r0,r1
+      ;ldr     r0,=20A6894h
+      ;ldrsh   r0,[r0,r1]
+      bl LevelListFirstHWORDGet
+      cmp     r0,5h
+      cmpne   r0,6h
+      cmpne   r0,8h
+      moveq   r0,0h
+      ;bxeq    r14
+      popeq r1,r15
+      @@Abort:
+      mov     r0,1h
+      ;bx      r14
+      pop r1,r15
+      .pool
+    .endarea
+
+;-------------------------------------
+; Level String Getter Hook
+;-------------------------------------
+    .org 0x020652E4 ; OK
+    .area 0x18 ; we got 24 bytes max here
+        push r14
+        ;Call our modified routine
+        bl LevelListStringAccessor ;We want only the string!!
+        pop r15
+        .pool
+        ;.fill (0x020652E4 + 0x18) - .,0
+    .endarea
+    ;END
+
+;-------------------------------------
+; FontLoader Hook (For loading as SIR0 only)
+;-------------------------------------
+    .org 0x2025AAC ; OK
+    .area (0x2025B48 - 0x2025AAC) ; OK
+      push r14
+      bl ReplacedFontLoader
+      pop r15
+      .pool
+      .fill (0x2025B48 - .),0 ; OK
+    .endarea
+    ;END
+
+
+;.close ;Close arm9.bin
+
+;.include "levellistloader_overlay11.asm"

--- a/src/jp/levellistloader_overlay11.asm
+++ b/src/jp/levellistloader_overlay11.asm
@@ -1,0 +1,214 @@
+; For use with ARMIPS v0.7d
+; By: psycommando@gmail.com
+; 2016/08/16 - Updated 2023/09/11
+; For Explorers of Sky Japan ONLY!
+; ------------------------------------------------------------------------------
+; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
+; This work is free. You can redistribute it and/or modify it under the
+; terms of the Do What The Fuck You Want To Public License, Version 2,
+; as published by Sam Hocevar. See http://www.wtfpl.net/ for more details.
+; ------------------------------------------------------------------------------
+.relativeinclude on
+.nds
+.arm
+
+;-------------------------------------
+; Hook 022DFC0C
+;-------------------------------------
+  .org 0x22DFC0C ; OK
+  .area 24  ;We have 24 bytes here
+    ldrsh   r3,[r0,8h]
+    mov     r0,r3
+    bl LevelListSecondHWORDGet;ldr     r2,=20A6896h ; OK
+    mov     r2,r0
+    mov     r0,0h ;smulbb  r1,r3,r1
+    nop ;ldrsh   r2,[r2,r1]
+  .endarea
+
+;-------------------------------------
+; Hook 022F2998
+;-------------------------------------
+  .org 0x22F2998 ; OK
+  .area 0x14  ;We have 20 bytes here
+    ;Prepare the parameter for the accessor
+    mov     r0,r5               ;022F2998 E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor   ;022F299C E1630085 smulbb  r3,r5,r0
+    mov     r4,r0               ;022F29A0 E59F41E4 ldr     r4,=20A6894h
+    ldrsh   r0,[r4]             ;022F29A4 E19400F3 ldrsh   r0,[r4,r3]
+    nop                         ;022F29A8 E0844003 add     r4,r4,r3
+  .endarea
+  .org 0x22F2B8C         ;We need to modify the address here, to use it for our bl above! ; OK
+  .area 4
+    .pool
+  .endarea
+
+;-------------------------------------
+; Hook 022F2C4C
+;-------------------------------------
+  .org 0x22F2C4C ; OK
+  .area 0x14
+    ;Prepare the parameter for the accessor
+    mov     r0,r8                 ;022F2C4C E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor     ;022F2C50 E1610088 smulbb  r1,r8,r0
+    mov     r4,r0                 ;022F2C54 E59F20EC ldr     r2,=20A6894h
+    ldrsh   r0,[r4]               ;022F2C58 E19200F1 ldrsh   r0,[r2,r1]
+    nop                           ;022F2C5C E0824001 add     r4,r2,r1
+  .endarea
+  .org 0x22F2D48 ; OK
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 022F2DA4
+  ;-------------------------------------
+  .org 0x22F2DA4 ; OK
+  .area 24
+    mov     r0,r4               ;022F2DA4 E59F1034 ldr     r1,=20A6894h   //<-change       //Level list beg
+    ldr     r3,[r2,4h]          ;!! Don't touch !!
+    bl      LevelListAccessor   ;022F2DAC E3A0000C mov     r0,0Ch
+    strh    r4,[r3]             ;!! Don't touch !!
+    ldrsh   r1,[r0,4h]          ;022F2DB4 E1001084 smlabb  r0,r4,r0,r1
+    nop                         ;022F2DB8 E1D010F4 ldrsh   r1,[r0,4h]
+  .endarea
+  .org 0x22F2DE0
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0x22F2E00 - This one caused misalignment in the stack!!
+  ;-------------------------------------
+  .org 0x22F2E00 ; OK
+  .area (0x22F2E30 - 0x22F2E00) ; OK
+    push r14                  ;022F2E00 E59F0024 ldr     r0,=2326220h
+    ldr     r0,=2326220h       ;022F2E04 E5900004 ldr     r0,[r0,4h] ; OK
+    ldr     r0,[r0,4h]         ;022F2E08 E3500000 cmp     r0,0h
+    cmp     r0,0h              ;022F2E0C 03E00000 mvneq   r0,0h
+    mvneq   r0,0h              ;022F2E10 012FFF1E bxeq    r14
+    popeq   r15                ;022F2E14 E1D020F0 ldrsh   r2,[r0]
+
+    ldrsh   r0,[r0]           ;022F2E18 E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor ;022F2E1C E59F100C ldr     r1,=20A6894h
+    ldrsh   r0,[r0]           ;022F2E20 E1600082 smulbb  r0,r2,r0
+    pop     r15               ;022F2E24 E19100F0 ldrsh   r0,[r1,r0]
+    .pool                     ;022F2E28 E12FFF1E bx      r14
+    ;.fill   (0x22F2E00 + 0x22F2E30) - . ;022F17E0 02326220 eoreqs  r4,r2,0C000h
+    ;022F2E30 020A5488 andeq   r5,r10,88000000h
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 022F35B4
+  ;-------------------------------------
+  .org 0x22F35B4 ; OK
+  .area 20
+    nop ;mov     r0,r4             ;022F35B4 E3A0300C mov     r3,0Ch
+    mov     r1,r7             ;!! Don't Touch !!
+    mov     r2,r6             ;!! Don't Touch !!
+    bl      LevelListCustomHook022F35B4 ;022F35C0 E1640384 smulbb  r4,r4,r3 ;;<== Custom hook for this one since we don't have much space, and a lot of registers are in use!
+    nop ;022F35C4 E59F50C8 ldr     r5,=20A6894h ;;;Put the result into r4 since r0 gets overwritten several times after, not r4 and r5
+  .endarea
+  .org 0x22F3624 ; OK
+  .area 4
+    ldrsh   r0,[r4]           ;022F3624 E19500F4 ldrsh   r0,[r5,r4]
+  .endarea
+  .org 0x22F3694 ; OK
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0230105C
+  ;-------------------------------------
+  .org 0x230105C ; OK
+  .area 24
+    push r14
+    mov     r0,r1                 ;0230105C E59F200C ldr     r2,=20A6894h
+    bl      LevelListAccessor     ;02301060 E3A0000C mov     r0,0Ch
+    ldr     r0,[r0,8h]            ;02301064 E0202091 mla     r0,r1,r0,r2
+    ;bx      r14                   ;02301068 E5900008 ldr     r0,[r0,8h]
+    pop r15
+    .pool                         ;0230106C E12FFF1E bx      r14
+    ;02301070 020A5488 andeq   r5,r10,88000000h
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0x23116B4
+  ;-------------------------------------
+  .org 0x23116B4 ; OK
+  .area 20
+    mov     r0,r5             ;023116B4 E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor ;023116B8 E1610085 smulbb  r1,r5,r0
+    mov     r4,r0             ;023116BC E59F3210 ldr     r3,=20A6894h
+    ldrsh   r0,[r4]           ;023116C0 E19300F1 ldrsh   r0,[r3,r1]
+    nop                       ;023116C4 E0834001 add     r4,r3,r1
+  .endarea
+  .org 0x23118D4 ; OK
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0x23123C8
+  ;-------------------------------------
+  .org 0x23123C8 ; OK
+  .area 4
+    nop     ;023123C8 E3A0000C mov     r0,0Ch        //<-change
+  .endarea
+  ;023123CC E2811902 add     r1,r1,8000h
+  ;023123D0 E5861000 str     r1,[r6]
+  ;023123D4 E5962004 ldr     r2,[r6,4h]
+  .org 0x23123D8 ; OK
+  .area 4
+    nop     ;023123D8 E1610084 smulbb  r1,r4,r0      //<-change
+  .endarea
+  ;023123DC E2820A06 add     r0,r2,6000h
+  ;023123E0 E5860004 str     r0,[r6,4h]
+  ;023123E4 E5952000 ldr     r2,[r5]
+  .org 0x23123E8 ; OK
+  .area 4
+    mov     r0,r4  ;023123E8 E59F0080 ldr     r0,=20A6894h  //<-change
+  .endarea
+  ;023123EC E2422902 sub     r2,r2,8000h
+  ;023123F0 E5852000 str     r2,[r5]
+  ;023123F4 E5952004 ldr     r2,[r5,4h]
+  .org 0x23123F8
+  .area 4
+    bl    LevelListFirstHWORDGet ;023123F8 E19000F1 ldrsh   r0,[r0,r1]    //<-change
+  .endarea
+  .org 0x2312470
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0x23126B8
+  ;-------------------------------------
+  .org 0x23126B8 ; OK
+  .area 20
+    mov     r0,r5             ;023126B8 E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor ;023126BC E1610085 smulbb  r1,r5,r0
+    mov     r4,r0             ;023126C0 E59F315C ldr     r3,=20A6894h
+    ldrsh   r0,[r4]           ;023126C4 E19300F1 ldrsh   r0,[r3,r1]
+    nop                       ;023126C8 E0834001 add     r4,r3,r1
+  .endarea
+  .org 0x02312824 ; OK
+  .area 4
+    .pool
+  .endarea
+
+  ;-------------------------------------
+  ; Hook 0x2313B54
+  ;-------------------------------------
+  .org 0x2313B54 ; OK
+  .area 20
+    mov     r0,r5             ;02313B54 E3A0000C mov     r0,0Ch
+    bl      LevelListAccessor ;02313B58 E1610085 smulbb  r1,r5,r0
+    mov     r4,r0             ;02313B5C E59F3138 ldr     r3,=20A6894h
+    ldrsh   r0,[r4]           ;02313B60 E19300F1 ldrsh   r0,[r3,r1]
+    nop                       ;02313B64 E0834001 add     r4,r3,r1
+  .endarea
+  .org 0x02313C9C ; OK
+  .area 4
+    .pool
+  .endarea

--- a/src/selector_arm9.asm
+++ b/src/selector_arm9.asm
@@ -1,6 +1,6 @@
 ; For use with ARMIPS v0.7d
 ; By: psycommando@gmail.com
-; 2020/11/17
+; 2020/11/17 - Updated 2023/9/11
 ; For Explorers of Sky All Versions
 ; ------------------------------------------------------------------------------
 ; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
@@ -18,6 +18,9 @@
 .elseif PPMD_GameVer == GameVer_EoS_EU
 	.include "eu/levellistloader_arm9.asm"
 	.include "eu/actorlistloader_arm9.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/levellistloader_arm9.asm"
+	.include "jp/actorlistloader_arm9.asm"
 .endif
 
 .relativeinclude off

--- a/src/selector_overlay11.asm
+++ b/src/selector_overlay11.asm
@@ -1,6 +1,6 @@
 ; For use with ARMIPS v0.7d
 ; By: psycommando@gmail.com
-; 2020/11/17
+; 2020/11/17 - Updated 2023/9/11
 ; For Explorers of Sky All Versions
 ; ------------------------------------------------------------------------------
 ; Copyright © 2016 Guillaume Lavoie-Drapeau <psycommando@gmail.com>
@@ -18,6 +18,9 @@
 .elseif PPMD_GameVer == GameVer_EoS_EU
 	.include "eu/levellistloader_overlay11.asm"
 	.include "eu/actorlistloader_overlay11.asm"
+.elseif PPMD_GameVer == GameVer_EoS_JP
+	.include "jp/levellistloader_overlay11.asm"
+	.include "jp/actorlistloader_overlay11.asm"
 .endif
 
 .relativeinclude off


### PR DESCRIPTION
Adds support for `ActorAndLevelLoader` to be applied on a JP ROM.
Tested on hardware, but not to a great extent. The game boots successfully and map transitions work.

Also, I corrected an EU address, but I don't see this used anywhere anyway.